### PR TITLE
Match eduroam config to official CAT

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -133,9 +133,9 @@ create_eduroam_iwd() {
 EAP-Method=PEAP
 EAP-Identity=anonymous@dtu.dk
 EAP-PEAP-CACert=/var/lib/iwd/ca_eduroam.pem
-EAP-PEAP-ServerDomainMask=ait-pisepsn03.win.dtu.dk
+EAP-PEAP-ServerDomainMask=ait-pisepsn04.win.dtu.dk;ait-pisepsn03.win.dtu.dk
 EAP-PEAP-Phase2-Method=MSCHAPV2
-EAP-PEAP-Phase2-Identity=$username
+EAP-PEAP-Phase2-Identity=${username}@dtu.dk
 EAP-PEAP-Phase2-Password=$password
 
 [Settings]

--- a/setup.sh
+++ b/setup.sh
@@ -135,7 +135,7 @@ EAP-Identity=anonymous@dtu.dk
 EAP-PEAP-CACert=/var/lib/iwd/ca_eduroam.pem
 EAP-PEAP-ServerDomainMask=ait-pisepsn04.win.dtu.dk;ait-pisepsn03.win.dtu.dk
 EAP-PEAP-Phase2-Method=MSCHAPV2
-EAP-PEAP-Phase2-Identity=${username}@dtu.dk
+EAP-PEAP-Phase2-Identity=username@dtu.dk
 EAP-PEAP-Phase2-Password=$password
 
 [Settings]

--- a/setup.sh
+++ b/setup.sh
@@ -135,7 +135,7 @@ EAP-Identity=anonymous@dtu.dk
 EAP-PEAP-CACert=/var/lib/iwd/ca_eduroam.pem
 EAP-PEAP-ServerDomainMask=ait-pisepsn04.win.dtu.dk;ait-pisepsn03.win.dtu.dk
 EAP-PEAP-Phase2-Method=MSCHAPV2
-EAP-PEAP-Phase2-Identity=username@dtu.dk
+EAP-PEAP-Phase2-Identity=$username
 EAP-PEAP-Phase2-Password=$password
 
 [Settings]


### PR DESCRIPTION
When looking at the official eduroam [CAT](https://cat.eduroam.org/)  (installer) for DTU, I noticed two significant differences with respect to `setup.sh`:

1. `EAP-PEAP-Phase2-Identity` is suffixed with `@dtu.dk`
2. There is an additional server domain mask: `ait-pisepsn04.win.dtu.dk`

The CAT technically only supports NetworkManager but the fields are equivalent.

This pull request rectifies these differences, and makes the connection much more stable in my experience.